### PR TITLE
Add proposed Fabtastic charter

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -10,6 +10,7 @@
     - [Independent Leadership Model](ilm-projects/independent-leadership-model.md)
     - [LCCC Project Charter](ilm-projects/lccc.md)
     - [LCS Project Charter](ilm-projects/lcs.md)
+    - [Fabtastic Project Charter](ilm-projects/fabtastic.md)
 - [LC Management](lc-management/README.md)
     - [LCMT Quorum](lc-management/lcmt-quorum.md)
     - [Standing Agenda Items](lc-mangement/standing-agenda-items.md)

--- a/src/ilm-projects/fabtastic.md
+++ b/src/ilm-projects/fabtastic.md
@@ -1,0 +1,33 @@
+# FabtaSTIC Project Leadership Charter
+
+The Administration of LC charters the Fabtastic Project and assigns authority over the project to a group of Leads. 
+
+## Purpose of the Fabtastic Project
+
+The Fabtastic project is created to design and develop physical tools including hardware and software, that pertain to the manufacture of electronics hardware, and any constituent, related, and associated subprojects.
+
+## Authorities of the Fabtastic Leads
+
+The Fabtastic Leads are so authorized to:
+
+1.  Create groups as they see fit to carry out their authorities and purposes,
+2.  Appoint or dismiss other Leads and people to such groups created above,
+3.  Set rules of order and other Governance rules for themselves and any groups they create,
+4.  Adopt a Code of Conduct for constructive contribution and discussion related to the Project and enforce that Code of Conduct among it's community and contributors,
+5.  Delegate their authorities as they see fit to other people and groups,
+6.  Develop the Fabtastic Project by making changes to the upstream Fabtastic Codebase and any design records maintained by the Fabtastic Leads,
+7.  Authorize and establish subprojects of the Fabtastic Project,
+8.  Authorize and establish subprojects of related and associated projects,
+9.  Request, as necessary, the intervention of the LC Admins in matters which exceed their capacity or authority to handle, or that are of significant impact to LC as a whole, and
+10. Manage the GitHub organization assigned to the project.
+11. Protect the proprietary interests of the Fabtastic Project and LC as it relates to the Fabtastic Project by entering into agreements related to confidentiality of relevant design details of the Fabtastic Project, it's constituent projects, and its related and associated projects, and to enforce such agreements.
+
+## Responsibilities of the Fantastic Leads
+
+Within 1 month of the establishment of the Project, the Fantastic Leads shall:
+1. Review this charter and ratify it or send it back to the LC Admins with suggested revisions and
+2. Create Project Governance Rules for making decisions regarding their authorities described in this charter and publish them in a manner they see fit.
+
+On a continuing basis, the Fantastic Leads shall:
+1. Maintain the Governance Rules adopted above, reviewing them, amending them, or adopting additional rules as they deem necessary, and
+2. Develop, maintain, and ensure the development and maintance of the Project, its constituent projects, and related and associated projects.

--- a/src/ilm-projects/fabtastic.md
+++ b/src/ilm-projects/fabtastic.md
@@ -21,6 +21,7 @@ The Fabtastic Leads are so authorized to:
 9.  Request, as necessary, the intervention of the LC Admins in matters which exceed their capacity or authority to handle, or that are of significant impact to LC as a whole, and
 10. Manage the GitHub organization assigned to the project.
 11. Protect the proprietary interests of the Fabtastic Project and LC as it relates to the Fabtastic Project by entering into agreements related to confidentiality of relevant design details of the Fabtastic Project, it's constituent projects, and its related and associated projects, and to enforce such agreements.
+12. File applications for intellectual property protections, including Patent and Copyright Registrations, related to the Fabtastic Project, it's constituent projects, and its related and associated projects, both on behalf of themselves and on behalf of LC.
 
 ## Responsibilities of the Fantastic Leads
 


### PR DESCRIPTION
This proposes to charter the Fabtastic Project as an ILM Project, due to special concerns and considerations arround project confidentiality that currently require special cases in the LC Governance to handle. 